### PR TITLE
made damage records save per character

### DIFF
--- a/ShaguBam.toc
+++ b/ShaguBam.toc
@@ -3,7 +3,8 @@
 ## Author: Shagu, 2016
 ## Notes: BamMod
 ## Version: 0.1
-## SavedVariables: ShaguBamSettings, ShaguBamRecord
+## SavedVariables: ShaguBamSettings
+## SavedVariablesPerCharacter: ShaguBamRecord
 
 # main
 ShaguBam.lua


### PR DESCRIPTION
Damage records are now saved per character instead of per account, which prevents overlapping records of characters of the same class, or damage done with autoattacks. It seems to make more sense to keep damage records local to each character, rather than keeping one record for all your characters of the same class on the entire server.